### PR TITLE
feat(config): Ubuntu 환경 분기용 Docker Compose 실행 구성을 추가한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+.env
+*.log
+
+# 앱 파일 로그(프로젝트 안에만 생성)
+data/mwa-logs/
+# Loki 청크·인덱스(로컬 바인드 마운트)
+data/loki/
+
+# monitoring/ 기준 compose 시 ./data 가 monitoring/data 로 생성됨
+monitoring/data/

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,40 @@
+# Monitoring stack run guide
+
+## Environment-specific compose support
+
+This directory now supports environment-specific compose execution:
+
+- `docker-compose.yml` (default/Desktop)
+- `docker-compose.ubuntu.yml` (Ubuntu + Docker Engine override)
+
+## Run commands
+
+From any current directory:
+
+```bash
+export USER_ID=$(id -u)
+/path/to/repo/monitoring/compose-env.sh up -d --build
+```
+
+Select Ubuntu explicitly:
+
+```bash
+export USER_ID=$(id -u)
+MONITORING_ENV=ubuntu /path/to/repo/monitoring/compose-env.sh up -d --build
+```
+
+The helper always loads base compose first and applies Ubuntu overrides only when `MONITORING_ENV=ubuntu`.
+
+Or run compose directly with explicit files:
+
+```bash
+export USER_ID=$(id -u)
+docker compose -f monitoring/docker-compose.yml -f monitoring/docker-compose.ubuntu.yml up -d --build
+```
+
+## Stop stack
+
+```bash
+MONITORING_ENV=ubuntu /path/to/repo/monitoring/compose-env.sh down
+/path/to/repo/monitoring/compose-env.sh down
+```

--- a/monitoring/compose-env.sh
+++ b/monitoring/compose-env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+environment="${MONITORING_ENV:-desktop}"
+compose_args=("-f" "$script_dir/docker-compose.yml")
+
+case "$environment" in
+  desktop)
+    ;;
+  ubuntu)
+    compose_args+=("-f" "$script_dir/docker-compose.ubuntu.yml")
+    ;;
+  *)
+    echo "Unsupported MONITORING_ENV: $environment" >&2
+    echo "Supported values: desktop, ubuntu" >&2
+    exit 1
+    ;;
+esac
+
+exec docker compose "${compose_args[@]}" "$@"

--- a/monitoring/config/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/config/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+# 기동 시 JSON 대시보드를 폴더「MWA」에 로드 (UI에서 수정 허용)
+apiVersion: 1
+
+providers:
+  - name: MWA
+    folder: MWA
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/monitoring/config/grafana/provisioning/dashboards/json/mwa-overview.json
+++ b/monitoring/config/grafana/provisioning/dashboards/json/mwa-overview.json
@@ -1,0 +1,381 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "1) 호스트 — Prometheus job=node (node_exporter)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "호스트 CPU 중 idle(유휴)이 아닌 비율을 퍼센트로 표시합니다. EC2 인스턴스 라벨 instance=ec2-mwa 기준입니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "100 - (avg by (instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU 사용률 (%) — idle 제외",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "사용 가능한 메모리 대비 전체 메모리 비율로 사용률을 냅니다. MemAvailable / MemTotal 기준.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "메모리 사용률 (%) — MemAvailable 기준",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 13,
+      "title": "1b) cAdvisor — Docker 컨테이너 (이미지 기준, Desktop/Ubuntu 호환)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "환경에 따라 cAdvisor의 id 라벨 형식이 `/docker/...` 또는 `/system.slice/docker-...` 로 다를 수 있습니다. `image` 라벨로 묶어 공통으로 보이도록 구성했습니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never" },
+          "unit": "short",
+          "decimals": 3
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 10 },
+      "id": 14,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (image) (rate(container_cpu_usage_seconds_total{id=~\"(/docker/.*|/system.slice/docker-.*\\\\.scope)\",id!~\".*buildkit.*\",image!=\"\"}[5m]))",
+          "legendFormat": "{{image}}",
+          "refId": "A"
+        }
+      ],
+      "title": "cAdvisor · CPU — Docker 이미지별 (초당 코어)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "working set 바이트. `image` 라벨로 묶음(Docker Desktop 에서 name 이 비는 경우 대비).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never" },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 10 },
+      "id": 15,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (image) (container_memory_working_set_bytes{id=~\"(/docker/.*|/system.slice/docker-.*\\\\.scope)\",id!~\".*buildkit.*\",image!=\"\"})",
+          "legendFormat": "{{image}}",
+          "refId": "A"
+        }
+      ],
+      "title": "cAdvisor · 메모리 working set — Docker 이미지별",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "containerd snapshotter 환경에서는 cAdvisor가 컨테이너별 네트워크 메트릭을 수집하지 못할 수 있어, 호스트 인터페이스별 수신 트래픽을 표시합니다. (lo·bridge·veth 제외)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never" },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 17 },
+      "id": 16,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(container_network_receive_bytes_total{id=\"/\",interface!~\"lo|docker0|br-.*|veth.*\"}[5m])",
+          "legendFormat": "{{interface}}",
+          "refId": "A"
+        }
+      ],
+      "title": "네트워크 수신 — 호스트 인터페이스별",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "containerd snapshotter 환경에서는 cAdvisor가 컨테이너별 네트워크 메트릭을 수집하지 못할 수 있어, 호스트 인터페이스별 송신 트래픽을 표시합니다. (lo·bridge·veth 제외)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never" },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 17 },
+      "id": 17,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(container_network_transmit_bytes_total{id=\"/\",interface!~\"lo|docker0|br-.*|veth.*\"}[5m])",
+          "legendFormat": "{{interface}}",
+          "refId": "A"
+        }
+      ],
+      "title": "네트워크 송신 — 호스트 인터페이스별",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "id": 4,
+      "title": "2) MWA 웹 — 모든 HTTP 응답이 끝날 때마다 올라가는 카운터 (mwa_http_requests_total)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "메트릭 mwa_http_requests_total: method·path·status 라벨이 붙습니다. [5m] = 최근 5분 구간에서 초당 평균 증가율(rate)을 계산합니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never" },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 5,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(mwa_http_requests_total[5m]))",
+          "legendFormat": "전체 초당 요청",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 처리 속도 — 전체 합산 (초당, 최근 5분 평균)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "같은 카운터를 path 라벨로 나눈 값입니다. /(메인), /action(폼 POST), /metrics, /health 등이 각각 따로 보입니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 15, "lineWidth": 2, "showPoints": "never" },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 6,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (path) (rate(mwa_http_requests_total[5m]))",
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP 처리 속도 — URL 경로(path)별 (초당, 최근 5분 평균)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "id": 7,
+      "title": "3) 데모 버튼(폼 전송) — 서버가 POST /action 을 처리한 횟수 (mwa_button_clicks_total)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "의미: 서버가 '버튼 → 폼 제출'을 받아 처리할 때마다 카운터가 1 올라갑니다. 그래프는 그 누적값을 시간으로 나눈 값이라, 세로축 = 초당 평균 몇 건이 처리됐는지(최근 5분 구간 기준)입니다. 장바구니/상품보기 등은 action 라벨로 구분되고, 단순 페이지 열람(GET /)은 이 패널에 안 잡힙니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "bars", "fillOpacity": 80, "lineWidth": 1, "showPoints": "never" },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 34 },
+      "id": 8,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (action) (rate(mwa_button_clicks_total[5m]))",
+          "legendFormat": "{{action}}",
+          "refId": "A"
+        }
+      ],
+      "title": "초당 처리된 폼 제출(버튼) 건수 — 최근 5분 평균, action 종류별",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 42 },
+      "id": 11,
+      "title": "3b) 데모 쇼핑 — 구매 확정 시에만 증가 (mwa_product_orders_total)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "상품 카드·랜덤 구매 버튼으로 주문이 기록될 때 product_id 라벨별로 카운트합니다. 로그에는 order_id·product_name·price_won 이 JSON 으로 같이 남습니다.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 20, "lineWidth": 2, "showPoints": "never" },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 43 },
+      "id": 12,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (product_id) (rate(mwa_product_orders_total[5m]))",
+          "legendFormat": "{{product_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "초당 처리된 구매 건수 — 상품(sku)별, 최근 5분 평균",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 51 },
+      "id": 9,
+      "title": "4) 로그 — Loki (Docker 로그, compose_service 라벨)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "description": "Promtail docker_sd가 붙인 compose_service=mwa-web 스트림입니다. stdout/stderr만 해당. JSON 줄에 event=order_placed 를 검색하면 주문 이벤트만 볼 수 있습니다.",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 52 },
+      "id": 10,
+      "options": {
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{compose_service=\"mwa-web\"}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "mwa-web 컨테이너 로그 (stdout/stderr)",
+      "type": "logs"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["mwa"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MWA 개요 — 메트릭·로그 패널 이름 가이드",
+  "uid": "mwa-overview",
+  "version": 7
+}

--- a/monitoring/config/grafana/provisioning/datasources/datasources.yml
+++ b/monitoring/config/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,34 @@
+# Grafana 기동 시 자동으로 데이터 소스 등록
+# URL은 컨테이너 간 통신 기준(브라우저가 아니라 Grafana → 백엔드)
+#
+# 기존 grafana_data DB 에 같은 이름·다른 uid 가 있으면 uid 고정 시 "data source not found" 로 기동 실패할 수 있어,
+# 매 기동 전 이름으로 지우고 아래 블록으로 다시 만듦(학습용 스택).
+
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+  - name: Loki
+    orgId: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    # access: proxy — "프록시" = 브라우저가 Prometheus에 직접 붙지 않고,
+    #   Grafana 서버가 대신 http://prometheus:9090 으로 요청을 넘김.
+    #   - 장점: 같은 Docker 네트워크 호스트명(prometheus, loki) 사용 가능, CORS·노출 범위 줄임.
+    # access: direct — 브라우저가 url 을 직접 호출(내 PC에서 prometheus:9090 은 안 됨).
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+
+  - name: Loki
+    uid: loki
+    type: loki
+    # 위와 동일: 질의는 Grafana 컨테이너 → Loki 로만 나감.
+    access: proxy
+    url: http://loki:3100
+    editable: true

--- a/monitoring/config/loki/loki-config.yml
+++ b/monitoring/config/loki/loki-config.yml
@@ -1,0 +1,87 @@
+# 참고: https://github.com/grafana/loki/blob/main/cmd/loki/loki-local-config.yaml
+
+auth_enabled: false
+
+server:
+  http_listen_address: 0.0.0.0
+ 
+  # HTTP: Loki 자체의 API 포트. Promtail 푸시(/loki/api/v1/push), Grafana·LogQL 조회
+  http_listen_port: 3100
+
+  # gRPC: Loki가 한 프로세스로 떠 있어도, 내부 모듈(ingester·querier 등)이 gRPC로 통신함.
+  # 내부통신용으로 Promtail/Grafana는 3100(HTTP)만 쓰고 이 포트에는 붙지 않음.
+  grpc_listen_port: 9096
+
+# common: 단일 바이너리여도 내부에 ingester·querier 등이 있어, 그들이 같이 쓰는 “공통” 설정 묶음.
+common:
+  # 이 인스턴스가 링(아래 ring)에 참여할 때, 다른 구성 요소에게 알려 줄 자기 주소. 단일 노드면 127.0.0.1.
+  instance_addr: 127.0.0.1
+
+  # 공식 단일 인스턴스 예시(loki-local-config)와 동일한 컨테이너 경로. 호스트는 docker-compose 의 ./data/loki → /tmp/loki.
+  path_prefix: /tmp/loki
+
+  storage:
+    filesystem:
+      # 실제 로그 조각(청크)이 쌓이는 디렉터리.
+      chunks_directory: /tmp/loki/chunks
+      # Ruler(로그 기반 알림 규칙)용 디렉터리. 알림을 안 써도 두어도 됨.
+      rules_directory: /tmp/loki/rules
+
+  # 복제본 수. 1 = 한 대만 쓰는 구성(학습·단일 EC2). 클러스터면 보통 3 등.
+  replication_factor: 1
+
+  # ring: 여러 인제스터가 “누가 어떤 로그 스트림을 담당할지” 나누기 위한 분산 해시 링.
+  ring:
+    kvstore:
+      # inmemory = 링 메타데이터만 메모리에 보관. 단일 프로세스·재시작 시 링은 초기화되지만
+      # 청크/인덱스는 위 디스크 경로에 남는 구성과 자주 같이 씀. 멀티 노드면 consul/etcd·memberlist 등.
+      store: inmemory
+
+# query_range: LogQL 조회 시 “어제~오늘”, “지난 7일”처럼 기간이 길수록 뒤에서 잘라 합치는 작업이 많아짐.
+# 그 중간 단계 결과를 잠깐 캐시해 두어, 비슷한 쿼리·대시보드 새로고침 시 응답을 빠르게 하려는 설정.
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+# Loki 3 단일 바이너리 예시(loki-local-config)에 있는 한도·집계 관련 스위치.
+limits_config:
+  metric_aggregation_enabled: true
+  enable_multi_variant_queries: true
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        # 인덱스 파일 이름 접두사.
+        prefix: index_
+        # 인덱스를 나누는 기간(테이블/기간 단위). 24h = 하루 단위로 롤링.
+        period: 24h
+
+# 패턴 감지·집계 관련 인제스터(Loki 3 예시 설정). 단일 바이너리에서 localhost:3100 은 자기 자신 HTTP API.
+pattern_ingester:
+  enabled: true
+  metric_aggregation:
+    loki_address: localhost:3100
+
+# Ruler: LogQL로 “로그 조건 → 알림” 규칙을 돌릴 때 쓰는 컴포넌트. MWA 스택엔 Alertmanager가 없음.
+ruler:
+  # 알림을 켜면 Prometheus Alertmanager 주소로 보냄. 안 쓰면 URL이 있어도 동작에 거의 영향 없음.
+  alertmanager_url: http://localhost:9093
+
+# 쿼리 프론트엔드와 백엔드 사이 인코딩. protobuf = 이진 프로토콜(효율). 공식 loki-local-config 와 동일.
+frontend:
+  encoding: protobuf
+
+# 청크·인덱스와 같은 볼륨(/tmp/loki) 아래에 두어 loki_data 한 개로 compactor 상태까지 영속화.
+compactor:
+  working_directory: /tmp/loki/compactor
+
+# Grafana Labs 쪽 익명 사용 통계 전송. 끄려면 아래 주석 해제.
+# analytics:
+#   reporting_enabled: false

--- a/monitoring/config/prometheus/prometheus.yml
+++ b/monitoring/config/prometheus/prometheus.yml
@@ -1,0 +1,56 @@
+# Prometheus가 "어디서" 메트릭을 긁어올지 정의
+# 모든 타깃은 docker-compose의 loki 네트워크 안에서 서비스 이름으로 접근합니다.
+#
+# EC2 퍼블릭 IP로 브라우저에서 볼 때:
+#   - Grafana   http://<EC2_IP>:3000
+#   - Prometheus http://<EC2_IP>:9090
+#   - MWA 데모 웹 http://<EC2_IP>:8080
+# 보안 그룹: 학습용으론 위 포트를 열어도 되지만, 운영에선 9090·3100·9100 은 퍼블릭에 두지 않는 편이 좋음.
+#   - 9090 Prometheus: 수집한 메트릭·타깃 정보가 그대로 노출(기본 인증 없음) → 인프라 정찰에 유리.
+#   - 3100 Loki: 로그 조회·푸시 API → 민감 로그 유출·악용 위험.
+#   - 9100 node_exporter: 호스트 CPU·메모리·디스크·프로세스 등 상세 노출 → 서버 내부 정보 유출.
+#   - 8088 cAdvisor: 컨테이너별 리소스·이름 노출 → 학습용만 퍼블릭에 두는 것 권장.
+# VPN·bastion·사설망·본인 IP만 허용 등으로 제한하고, 대시보드는 보통 3000(Grafana)만 제한적으로 연다.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # cAdvisor 응답이 크고 느릴 수 있어 타임아웃·간격을 넉넉히(스크랩 실패 시 Targets 에 DOWN)
+  - job_name: cadvisor
+    scrape_interval: 30s
+    scrape_timeout: 25s
+    static_configs:
+      - targets: ["cadvisor:8080"]
+
+  - job_name: node
+    static_configs:
+      - targets: ["node-exporter:9100"]
+        labels:
+          # 인스턴스 구분용
+          instance: ec2-mwa
+
+  # Prometheus 자기 자신
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # MWA 데모 웹(Express). npm 패키지 prom-client 가 카운터 등을 모아
+  #   GET http://mwa-web:8080/metrics
+  # 에 Prometheus 형식 텍스트로 내려줌 → Prometheus 가 주기적으로 이 URL을 긁음(scrape).
+  - job_name: mwa-web
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["mwa-web:8080"]
+        labels:
+          app: mwa
+
+  # Docker 밖 호스트에서 뜬 앱(예: systemd로 직접 실행)을 스크랩할 때:
+  # 1) 호스트에서 메트릭 포트 열기
+  # 2) 아래 주석 해제 후 포트 맞추기 (linux EC2에서 host.docker.internal 은 compose extra_hosts 사용)
+  # - job_name: host-process
+  #   static_configs:
+  #     - targets: ["host.docker.internal:9091"]
+  #       labels:
+  #         app: my-binary

--- a/monitoring/config/promtail/promtail-config.yml
+++ b/monitoring/config/promtail/promtail-config.yml
@@ -1,0 +1,45 @@
+# Push 대상 = compose 서비스 이름 loki
+# stdout vs 파일 연동 가이드: README「애플리케이션 로그 연동」
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # (선택) 맥/EC2 의 /var/log 를 compose 로 promtail 컨테이너에 마운트했을 때만 의미 있음.
+  # Promtail 이 보는 경로는 "컨테이너 안" /var/log 이고, 내용은 호스트 /var/log 와 동일.
+  - job_name: host-files
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: host
+          __path__: /var/log/**/*.log
+
+  # B. 파일 로그: compose 가 ./data/mwa-logs 를 여기 /var/mwa-app-logs 로 마운트
+  - job_name: mwa-app-files
+    static_configs:
+      - targets: [localhost]
+        labels:
+          job: mwa-web-file
+          service_name: mwa-web
+          __path__: /var/mwa-app-logs/*.log
+
+  # A. stdout/stderr: docker.sock → 컨테이너 로그 전체 (고권한, 일반적인 단일 호스트 패턴)
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        regex: "/(.*)"
+        target_label: container
+      - source_labels: [__meta_docker_container_log_stream]
+        target_label: stream
+      - source_labels: [__meta_docker_container_label_com_docker_compose_service]
+        target_label: compose_service

--- a/monitoring/demo/.dockerignore
+++ b/monitoring/demo/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.git

--- a/monitoring/demo/Dockerfile
+++ b/monitoring/demo/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+RUN apk add --no-cache su-exec
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY server.js ./
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+EXPOSE 8080
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/monitoring/demo/docker-entrypoint.sh
+++ b/monitoring/demo/docker-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+mkdir -p /app/logs
+chown -R node:node /app/logs
+exec su-exec node node server.js

--- a/monitoring/demo/package.json
+++ b/monitoring/demo/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mwa",
+  "version": "1.0.0",
+  "private": true,
+  "description": "MWA 데모 웹 — 버튼 클릭 시 로그·메트릭 발생",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.21.2",
+    "morgan": "^1.10.0",
+    "prom-client": "^15.1.3"
+  }
+}

--- a/monitoring/demo/server.js
+++ b/monitoring/demo/server.js
@@ -1,0 +1,241 @@
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const express = require("express");
+const morgan = require("morgan");
+const client = require("prom-client");
+
+const PORT = process.env.PORT || 8080;
+const LOG_DIR = process.env.LOG_DIR || "/app/logs";
+const LOG_ACCESS = path.join(LOG_DIR, "mwa-access.log");
+const LOG_APP = path.join(LOG_DIR, "mwa-app.log");
+
+/**
+ * 데모용 고정 상품(카탈로그).
+ * id 접두사 sku = Stock Keeping Unit(재고·품목 관리용 코드, 매장/쇼핑몰에서 흔히 쓰는 품번). 화면에는 한글 이름만 노출.
+ * 메트릭 라벨 product_id 로 쓰이므로 짧고 고정된 값만 둠.
+ */
+const PRODUCTS = [
+  { id: "sku-notebook", name: "클라우드클럽 노트", price: 12000 },
+  { id: "sku-mug", name: "MWA 머그컵", price: 8900 },
+  { id: "sku-sticker", name: "데브옵스 스티커 팩", price: 3500 },
+];
+
+function appendLog(filePath, line) {
+  const text = line.endsWith("\n") ? line : `${line}\n`;
+  fs.appendFile(filePath, text, (err) => {
+    if (err) console.error(`appendLog ${filePath}:`, err.message);
+  });
+}
+
+function pickRandomProduct() {
+  return PRODUCTS[Math.floor(Math.random() * PRODUCTS.length)];
+}
+
+function renderPage() {
+  const productRows = PRODUCTS.map(
+    (p) => `
+  <article class="card">
+    <div class="card-body">
+      <h2>${escapeHtml(p.name)}</h2>
+      <p class="price">${p.price.toLocaleString("ko-KR")}원</p>
+      <form method="post" action="/action">
+        <input type="hidden" name="action" value="buy" />
+        <input type="hidden" name="product_id" value="${escapeHtml(p.id)}" />
+        <button type="submit">이 상품 구매</button>
+      </form>
+    </div>
+  </article>`
+  ).join("");
+
+  return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MWA 데모 쇼핑</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 520px; margin: 2rem auto; padding: 0 1rem; background: #f6f7f9; }
+    h1 { font-size: 1.35rem; margin-bottom: 0.25rem; }
+    .lead { color: #444; margin: 0 0 1rem; font-size: 0.95rem; }
+    .muted { color: #666; font-size: 0.85rem; }
+    .card { background: #fff; border-radius: 12px; box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 0.75rem; overflow: hidden; }
+    .card-body { padding: 1rem 1.1rem; }
+    .card h2 { font-size: 1.05rem; margin: 0 0 0.35rem; }
+    .price { font-weight: 600; color: #1a5f2a; margin: 0 0 0.75rem; }
+    button { width: 100%; padding: 0.65rem; cursor: pointer; font-size: 0.95rem; border-radius: 8px; border: 1px solid #ccc; background: #fff; }
+    button:hover { background: #f0f4ff; border-color: #99b; }
+    .random { margin: 1rem 0; padding: 1rem; background: #eef3ff; border-radius: 12px; border: 1px dashed #88a; }
+    .random button { background: #2c4bff; color: #fff; border: none; font-weight: 600; }
+    .random button:hover { background: #1f3ae0; }
+    .legacy { margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid #ddd; }
+    .legacy form { margin: 0.4rem 0; }
+    .legacy button { font-size: 0.88rem; padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>MWA 데모 쇼핑</h1>
+  <p class="lead">상품을 구매하면 JSON 로그(Loki)·메트릭(Prometheus)에 <strong>상품 id·주문 번호</strong>가 남습니다.</p>
+  <p class="muted">stdout + 파일 로그 · README「애플리케이션 로그 연동」</p>
+
+  ${productRows}
+
+  <div class="random">
+    <p class="muted" style="margin:0 0 0.5rem">서버가 카탈로그에서 <strong>무작위로 하나</strong> 골라 주문 이벤트를 남깁니다.</p>
+    <form method="post" action="/action">
+      <input type="hidden" name="action" value="buy_random" />
+      <button type="submit">랜덤 상품 구매 시뮬레이션</button>
+    </form>
+  </div>
+
+  <section class="legacy">
+    <p class="muted">기존 데모 액션 (메트릭 action 라벨용)</p>
+    <form method="post" action="/action">
+      <input type="hidden" name="action" value="add_to_cart" />
+      <button type="submit">장바구니 담기</button>
+    </form>
+    <form method="post" action="/action">
+      <input type="hidden" name="action" value="checkout" />
+      <button type="submit">주문하기</button>
+    </form>
+    <form method="post" action="/action">
+      <input type="hidden" name="action" value="view_product" />
+      <button type="submit">상품 상세 보기</button>
+    </form>
+  </section>
+
+  <p class="muted"><a href="/metrics">/metrics</a> — Prometheus · <code>mwa_product_orders_total</code></p>
+</body>
+</html>`;
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const register = new client.Registry();
+client.collectDefaultMetrics({ register });
+
+const httpRequests = new client.Counter({
+  name: "mwa_http_requests_total",
+  help: "HTTP 요청 수",
+  labelNames: ["method", "path", "status"],
+  registers: [register],
+});
+
+const buttonClicks = new client.Counter({
+  name: "mwa_button_clicks_total",
+  help: "버튼(액션) 클릭 수",
+  labelNames: ["action"],
+  registers: [register],
+});
+
+const productOrders = new client.Counter({
+  name: "mwa_product_orders_total",
+  help: "상품별 구매(주문) 건수 — 데모",
+  labelNames: ["product_id"],
+  registers: [register],
+});
+
+const app = express();
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+
+morgan.token("body", (req) => {
+  if (req.method === "POST" && req.body && typeof req.body === "object") {
+    return JSON.stringify(req.body);
+  }
+  return "-";
+});
+
+app.use(
+  morgan(
+    ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" body=:body',
+    {
+      stream: {
+        write: (line) => {
+          const l = `${line.trim()}\n`;
+          process.stdout.write(l);
+          appendLog(LOG_ACCESS, l);
+        },
+      },
+    }
+  )
+);
+
+app.use((req, res, next) => {
+  res.on("finish", () => {
+    const routePath = req.route?.path || req.path || "unknown";
+    httpRequests.inc({
+      method: req.method,
+      path: String(routePath),
+      status: String(res.statusCode),
+    });
+  });
+  next();
+});
+
+app.get("/", (_req, res) => {
+  res.type("html").send(renderPage());
+});
+
+function logOrderEvent(payload) {
+  const line = JSON.stringify(payload);
+  console.log(line);
+  appendLog(LOG_APP, line);
+}
+
+app.post("/action", (req, res) => {
+  const action = (req.body && req.body.action) || "unknown";
+  buttonClicks.inc({ action });
+
+  let product = null;
+  if (action === "buy_random") {
+    product = pickRandomProduct();
+  } else if (action === "buy" && req.body && req.body.product_id) {
+    product = PRODUCTS.find((p) => p.id === req.body.product_id) || null;
+  }
+
+  if (product) {
+    const orderId = `ord_${Date.now()}_${crypto.randomBytes(3).toString("hex")}`;
+    productOrders.inc({ product_id: product.id });
+    logOrderEvent({
+      event: "order_placed",
+      action,
+      order_id: orderId,
+      product_id: product.id,
+      product_name: product.name,
+      price_won: product.price,
+      ts: new Date().toISOString(),
+    });
+  } else {
+    const msg = { event: "button_click", action, ts: new Date().toISOString() };
+    logOrderEvent(msg);
+  }
+
+  res.redirect("/");
+});
+
+app.get("/metrics", async (_req, res) => {
+  res.set("Content-Type", register.contentType);
+  res.end(await register.metrics());
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.listen(PORT, "0.0.0.0", () => {
+  const line = JSON.stringify({
+    event: "server_start",
+    port: PORT,
+    catalog_skus: PRODUCTS.map((p) => p.id),
+    ts: new Date().toISOString(),
+  });
+  console.log(line);
+  appendLog(LOG_APP, line);
+});

--- a/monitoring/docker-compose.ubuntu.yml
+++ b/monitoring/docker-compose.ubuntu.yml
@@ -1,0 +1,14 @@
+services:
+  cadvisor:
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+      - /run/containerd/containerd.sock:/run/containerd/containerd.sock:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command:
+      - --housekeeping_interval=15s
+      - --containerd=/run/containerd/containerd.sock
+      - --containerd-namespace=moby

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,133 @@
+name: mwa
+
+# 실행(모니터링 폴더에서): export USER_ID=$(id -u) && docker compose up -d --build
+# 실행(루트에서): export USER_ID=$(id -u) && docker compose -f monitoring/docker-compose.yml up -d --build
+# 포트: 8080 웹 · 3000 Grafana · 9090 Prometheus · 3100 Loki · 9100 node_exporter · 8088 cAdvisor(컨테이너 메트릭)
+# 앱 로그(stdout vs 파일) 합치는 법 → README「애플리케이션 로그 연동」
+
+services:
+  mwa-web:
+    build: ./demo
+    container_name: mwa-web
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data/mwa-logs:/app/logs
+    restart: unless-stopped
+    networks:
+      - loki
+
+  grafana:
+    container_name: mwa-grafana
+    image: grafana/grafana:latest
+    user: ${USER_ID:-472}
+    environment:
+      # 첫 로그인 admin / admin
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_DEFAULT_THEME=light
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./config/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+      - loki
+    networks:
+      - loki
+
+  loki:
+    container_name: mwa-loki
+    image: grafana/loki:3.6.0
+    volumes:
+      - ./config/loki:/etc/loki:ro
+      # 공식 예시와 동일한 컨테이너 경로(/tmp/loki). 호스트 ./data/loki 에 두어 Finder/IDE에서 청크·인덱스 확인 가능
+      - ./data/loki:/tmp/loki
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
+    command: -config.file=/etc/loki/loki-config.yml
+    networks:
+      - loki
+
+  promtail:
+    container_name: mwa-promtail
+    image: grafana/promtail:2.9.8
+    volumes:
+      # 앱이 파일로 남긴 로그(프로젝트 ./data) → promtail-config 의 mwa-app-files job
+      - ./data/mwa-logs:/var/mwa-app-logs:ro
+      # 호스트 OS·데몬 로그 → host-files job (맥/EC2 의 /var/log)
+      - /var/log:/var/log:ro
+      # Docker API — 컨테이너 stdout/stderr 스트림을 읽기 위한 통로 (로그 파일 아님) → docker job
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./config/promtail:/etc/promtail:ro
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail-config.yml
+    networks:
+      - loki
+
+  prometheus:
+    container_name: mwa-prometheus
+    image: prom/prometheus:latest
+    volumes:
+      - ./config/prometheus:/etc/prometheus:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+    networks:
+      - loki
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+
+  # 컨테이너별 CPU·메모리 등. Docker Desktop 에선 cgroup/경로 제한으로 지표가 비거나 늦게 뜰 수 있음 → README 트러블슈팅 참고.
+  cadvisor:
+    container_name: mwa-cadvisor
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    privileged: true
+    ports:
+      - "8088:8080"
+    # docker.sock: 컨테이너 메타·Docker 전용 경로와 맞추기(Desktop 에서 지표 안 뜰 때 차이 나는 경우 많음)
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command:
+      - --housekeeping_interval=15s
+      - --docker_only=true
+    restart: unless-stopped
+    networks:
+      - loki
+
+  node-exporter:
+    container_name: mwa-node-exporter
+    image: prom/node-exporter:latest
+    ports:
+      - "9100:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--path.rootfs=/rootfs"
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+    restart: unless-stopped
+    networks:
+      - loki
+
+networks:
+  loki:
+
+volumes:
+  grafana_data:
+  prometheus_data:


### PR DESCRIPTION
## Summary
- `monitoring/` 경로에 Grafana/Loki/Prometheus/Promtail/cAdvisor/node-exporter 및 demo 앱을 포함한 모니터링 스택을 추가했습니다.
- Ubuntu 환경에서 런타임 차이를 반영할 수 있도록 `docker-compose.ubuntu.yml` override와 `compose-env.sh` 실행 스크립트를 추가해 환경 분기(`desktop`/`ubuntu`)를 지원합니다.
- Grafana `mwa-overview` 대시보드를 Desktop/Ubuntu(cAdvisor id 패턴, host 네트워크 인터페이스 필터) 공통 기준으로 조정했습니다.

## Key Files
- `.gitignore`
- `monitoring/docker-compose.yml`
- `monitoring/docker-compose.ubuntu.yml`
- `monitoring/compose-env.sh`
- `monitoring/config/**`
- `monitoring/demo/**`
- `monitoring/README.md`

## Test Plan
- [x] `bash -n monitoring/compose-env.sh`
- [x] `monitoring/compose-env.sh config`
- [x] `MONITORING_ENV=ubuntu monitoring/compose-env.sh config`
- [x] `docker compose -f monitoring/docker-compose.yml -f monitoring/docker-compose.ubuntu.yml config`
- [x] `python3 -m json.tool monitoring/config/grafana/provisioning/dashboards/json/mwa-overview.json`

## Notes
- 기존 `add-dockercompose` 브랜치는 `main`과 공통 히스토리가 없어 PR 생성이 불가하여, `main` 기반 브랜치(`feat/add-dockercompose-main`)에 동일 내용을 이식해 PR을 생성했습니다.